### PR TITLE
feat: thêm Peer Drop - gửi file P2P qua WebRTC - không cần server !

### DIFF
--- a/src/views/peer-drop/index.vue
+++ b/src/views/peer-drop/index.vue
@@ -1,0 +1,557 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import { useWebrtcFileTransfer, formatBytes } from './use-webrtc-file-transfer'
+import PeerDropGuidelineModal from './peer-drop-guideline-modal.vue'
+
+const route = useRoute()
+
+const {
+  state,
+  errorMessage,
+  isLoading,
+  offerSdp,
+  answerSdp,
+  selectedFiles,
+  sendProgress,
+  totalBytes,
+  incomingFiles,
+  receiveProgress,
+  bytesReceived,
+  receiveTotalBytes,
+  downloadReady,
+  selectFiles,
+  removeFile,
+  createOffer,
+  joinWithOffer,
+  acceptAnswer,
+  downloadFiles,
+  disconnect,
+} = useWebrtcFileTransfer()
+
+const pastedAnswer = ref('')
+const pastedOffer = ref('')
+const copied = ref(false)
+const linkCopied = ref(false)
+const hasOfferFromUrl = ref(false)
+const showGuideline = ref(false)
+const isDragOver = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+// Rotating loading messages
+const loadingMessages = [
+  'Đang tạo mã kết nối...',
+  'Đang tìm đường kết nối tốt nhất...',
+  'Đang chuẩn bị kết nối...',
+  'Sắp xong rồi...',
+]
+const loadingMsgIndex = ref(0)
+let loadingInterval: ReturnType<typeof setInterval> | null = null
+
+// Watch loading state for rotating messages
+import { watchEffect } from 'vue'
+watchEffect(() => {
+  if (isLoading.value) {
+    loadingMsgIndex.value = 0
+    loadingInterval = setInterval(() => {
+      loadingMsgIndex.value = (loadingMsgIndex.value + 1) % loadingMessages.length
+    }, 2500)
+  } else if (loadingInterval) {
+    clearInterval(loadingInterval)
+    loadingInterval = null
+  }
+})
+
+// File metadata encoded in URL for receiver preview
+const filesMeta = computed(() => {
+  const hash = window.location.hash
+  if (!hash.includes('&files=')) return null
+  try {
+    const filesParam = hash.split('&files=')[1] ?? ''
+    return JSON.parse(decodeURIComponent(filesParam))
+  } catch {
+    return null
+  }
+})
+
+// Auto-detect offer from URL hash
+onMounted(() => {
+  const hash = window.location.hash
+  if (hash.startsWith('#offer=')) {
+    try {
+      const offerPart = hash.split('&files=')[0] ?? ''
+      const encoded = offerPart.slice('#offer='.length)
+      pastedOffer.value = decodeURIComponent(encoded)
+      hasOfferFromUrl.value = true
+    } catch {
+      // Invalid hash, ignore
+    }
+  }
+})
+
+/** Generate shareable link with offer + file metadata */
+function generateShareLink(base64Sdp: string): string {
+  const meta = selectedFiles.value.map((f) => ({
+    name: f.name,
+    size: f.size,
+  }))
+  const filesParam = encodeURIComponent(JSON.stringify(meta))
+  return `${window.location.origin}${route.path}#offer=${encodeURIComponent(base64Sdp)}&files=${filesParam}`
+}
+
+async function safeCopy(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function copyShareLink() {
+  const link = generateShareLink(offerSdp.value)
+  linkCopied.value = await safeCopy(link)
+  if (linkCopied.value) setTimeout(() => (linkCopied.value = false), 2000)
+}
+
+async function handleCreateOffer() {
+  const sdp = await createOffer()
+  if (sdp) {
+    const link = generateShareLink(sdp)
+    linkCopied.value = await safeCopy(link)
+    if (linkCopied.value) setTimeout(() => (linkCopied.value = false), 3000)
+  }
+}
+
+async function handleJoin() {
+  if (window.location.hash) {
+    history.replaceState(null, '', route.path)
+  }
+  const answer = await joinWithOffer(pastedOffer.value)
+  if (answer) {
+    copied.value = await safeCopy(answer)
+    if (copied.value) setTimeout(() => (copied.value = false), 3000)
+  }
+}
+
+async function handleAcceptAnswer() {
+  await acceptAnswer(pastedAnswer.value)
+}
+
+async function copyToClipboard(text: string) {
+  copied.value = await safeCopy(text)
+  if (copied.value) setTimeout(() => (copied.value = false), 2000)
+}
+
+// Drag and drop handlers
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = true
+}
+
+function onDragLeave() {
+  isDragOver.value = false
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = false
+  const files = Array.from(e.dataTransfer?.files || [])
+  if (files.length > 0) {
+    selectFiles([...selectedFiles.value, ...files])
+  }
+}
+
+function onFileSelect(e: Event) {
+  const input = e.target as HTMLInputElement
+  const files = Array.from(input.files || [])
+  if (files.length > 0) {
+    selectFiles([...selectedFiles.value, ...files])
+  }
+  input.value = ''
+}
+
+function triggerFileInput() {
+  fileInput.value?.click()
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-bg-deep text-text-primary font-body px-4 py-8">
+    <div class="mx-auto max-w-3xl">
+      <!-- Header -->
+      <div class="mb-10 animate-fade-up">
+        <div class="flex items-center gap-3 mb-2">
+          <h1 class="font-display text-4xl sm:text-5xl font-bold text-accent-coral">
+            Peer Drop
+          </h1>
+          <button
+            class="border border-border-default bg-bg-surface px-3 py-1 text-xs font-display text-text-secondary transition hover:border-accent-coral hover:text-text-primary"
+            @click="showGuideline = true"
+          >
+            ? Hướng dẫn
+          </button>
+        </div>
+        <p class="text-text-secondary text-lg">
+          Gửi file P2P trực tiếp qua trình duyệt — không cần server.
+        </p>
+      </div>
+
+      <!-- Error -->
+      <div
+        v-if="errorMessage"
+        class="mb-6 border border-accent-coral/40 bg-accent-coral/10 p-4 text-sm text-accent-coral animate-fade-up"
+      >
+        {{ errorMessage }}
+      </div>
+
+      <!-- STATE: IDLE — File picker + drag-drop -->
+      <div v-if="state === 'idle' || state === 'files-ready'" class="space-y-6 animate-fade-up animate-delay-2">
+
+        <!-- Receiver from URL (has offer) -->
+        <div v-if="hasOfferFromUrl && state === 'idle'" class="space-y-6">
+          <h2 class="font-display text-2xl font-semibold flex items-center gap-3">
+            <span class="text-accent-sky font-display text-sm tracking-widest">//</span>
+            Nhận file
+          </h2>
+
+          <!-- File preview from URL -->
+          <div v-if="filesMeta" class="border border-border-default bg-bg-surface p-4">
+            <p class="text-xs text-text-dim mb-3">Bạn sắp nhận:</p>
+            <div class="space-y-2">
+              <div
+                v-for="(file, i) in filesMeta"
+                :key="i"
+                class="flex items-center justify-between text-sm border border-border-default bg-bg-deep px-3 py-2"
+              >
+                <span class="text-text-primary truncate mr-3">{{ file.name }}</span>
+                <span class="text-text-dim text-xs whitespace-nowrap">{{ formatBytes(file.size) }}</span>
+              </div>
+            </div>
+          </div>
+
+          <button
+            :disabled="!pastedOffer.trim()"
+            class="w-full border border-accent-sky bg-accent-sky/10 px-4 py-3 text-sm font-display text-accent-sky transition hover:bg-accent-sky/20 disabled:opacity-30 disabled:cursor-not-allowed"
+            @click="handleJoin"
+          >
+            Nhận file
+          </button>
+        </div>
+
+        <!-- Sender flow -->
+        <template v-if="!hasOfferFromUrl">
+          <h2 class="font-display text-2xl font-semibold flex items-center gap-3">
+            <span class="text-accent-coral font-display text-sm tracking-widest">//</span>
+            Chọn file để gửi
+          </h2>
+
+          <!-- Drop zone -->
+          <div
+            class="border-2 border-dashed p-8 text-center transition-all duration-300 cursor-pointer"
+            :class="isDragOver
+              ? 'border-accent-coral bg-accent-coral/5'
+              : 'border-border-default bg-bg-surface hover:border-accent-coral/50'"
+            @dragover="onDragOver"
+            @dragleave="onDragLeave"
+            @drop="onDrop"
+            @click="triggerFileInput"
+          >
+            <input
+              ref="fileInput"
+              type="file"
+              multiple
+              class="hidden"
+              @change="onFileSelect"
+            />
+            <div class="space-y-2">
+              <svg class="mx-auto w-12 h-12 text-text-dim" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+              </svg>
+              <p class="text-text-secondary text-sm">
+                Kéo thả file vào đây hoặc <span class="text-accent-coral">bấm để chọn</span>
+              </p>
+              <p class="text-text-dim text-xs">Hỗ trợ nhiều file cùng lúc</p>
+            </div>
+          </div>
+
+          <!-- Selected files list -->
+          <div v-if="selectedFiles.length > 0" class="space-y-3">
+            <div class="flex items-center justify-between">
+              <p class="text-xs text-text-dim font-display tracking-wide">
+                // {{ selectedFiles.length }} file — {{ formatBytes(totalBytes) }}
+              </p>
+              <button
+                class="text-xs text-text-dim hover:text-accent-coral transition"
+                @click="triggerFileInput"
+              >
+                + Thêm file
+              </button>
+            </div>
+            <div class="space-y-2">
+              <div
+                v-for="(file, i) in selectedFiles"
+                :key="i"
+                class="flex items-center justify-between border border-border-default bg-bg-surface px-4 py-2.5"
+              >
+                <div class="flex-1 min-w-0 mr-3">
+                  <p class="text-sm text-text-primary truncate">{{ file.name }}</p>
+                  <p class="text-xs text-text-dim">{{ formatBytes(file.size) }}</p>
+                </div>
+                <button
+                  class="text-text-dim hover:text-accent-coral transition text-xs"
+                  @click="removeFile(i)"
+                >
+                  Xoá
+                </button>
+              </div>
+            </div>
+
+            <!-- Create offer button -->
+            <button
+              class="w-full border border-accent-coral bg-accent-coral/10 px-4 py-3 text-sm font-display text-accent-coral transition hover:bg-accent-coral/20"
+              @click="handleCreateOffer"
+            >
+              Tạo link mời
+            </button>
+          </div>
+
+          <!-- Manual join section -->
+          <div class="border border-border-default bg-bg-surface p-6 mt-4">
+            <p class="font-display text-lg font-semibold text-text-primary mb-2">Nhận file</p>
+            <p class="text-sm text-text-secondary mb-3">
+              Dán mã kết nối từ người gửi.
+            </p>
+            <textarea
+              v-model="pastedOffer"
+              placeholder="Dán mã mời tại đây..."
+              class="w-full bg-bg-deep border border-border-default p-3 text-xs text-text-primary placeholder:text-text-dim resize-none h-24 focus:border-accent-sky focus:outline-none"
+            />
+            <button
+              :disabled="!pastedOffer.trim()"
+              class="mt-3 w-full border border-accent-sky bg-accent-sky/10 px-4 py-2 text-sm font-display text-accent-sky transition hover:bg-accent-sky/20 disabled:opacity-30 disabled:cursor-not-allowed"
+              @click="handleJoin"
+            >
+              Kết nối
+            </button>
+          </div>
+        </template>
+      </div>
+
+      <!-- STATE: CREATING-OFFER / WAITING-ANSWER -->
+      <div v-if="state === 'creating-offer' || state === 'waiting-answer'" class="space-y-6 animate-fade-up">
+        <h2 class="font-display text-2xl font-semibold flex items-center gap-3">
+          <span class="text-accent-amber font-display text-sm tracking-widest">//</span>
+          Bước 1: Gửi link này cho người nhận
+        </h2>
+
+        <div class="border border-border-default bg-bg-surface p-4">
+          <p v-if="isLoading" class="text-sm text-text-dim py-4 text-center animate-pulse">
+            {{ loadingMessages[loadingMsgIndex] }}
+          </p>
+          <template v-else>
+            <p class="text-xs text-text-dim mb-3">
+              Gửi link cho người muốn nhận file. Họ mở link sẽ thấy danh sách file bạn gửi.
+            </p>
+            <button
+              :disabled="!offerSdp"
+              class="w-full border border-accent-coral bg-accent-coral/10 px-4 py-3 text-sm font-display text-accent-coral transition hover:bg-accent-coral/20 disabled:opacity-30 disabled:cursor-not-allowed"
+              @click="copyShareLink"
+            >
+              {{ linkCopied ? 'Đã copy link!' : 'Copy link mời' }}
+            </button>
+
+            <details class="mt-3">
+              <summary class="text-xs text-text-dim cursor-pointer hover:text-text-secondary transition">
+                Hoặc copy mã thủ công
+              </summary>
+              <textarea
+                :value="offerSdp"
+                readonly
+                class="mt-2 w-full bg-bg-deep border border-border-default p-3 text-xs text-text-secondary resize-none h-28 focus:outline-none"
+              />
+              <button
+                :disabled="!offerSdp"
+                class="mt-2 border border-border-default bg-bg-surface px-4 py-2 text-xs font-display text-text-secondary transition hover:border-accent-coral hover:text-text-primary"
+                @click="copyToClipboard(offerSdp)"
+              >
+                {{ copied ? 'Đã copy!' : 'Copy mã mời' }}
+              </button>
+            </details>
+          </template>
+        </div>
+
+        <!-- Files being sent -->
+        <div class="border border-border-default bg-bg-surface p-4">
+          <p class="text-xs text-text-dim mb-2">File đang chờ gửi:</p>
+          <div class="space-y-1">
+            <div
+              v-for="(file, i) in selectedFiles"
+              :key="i"
+              class="flex items-center justify-between text-xs px-2 py-1.5"
+            >
+              <span class="text-text-secondary truncate mr-2">{{ file.name }}</span>
+              <span class="text-text-dim whitespace-nowrap">{{ formatBytes(file.size) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <h2 class="font-display text-2xl font-semibold flex items-center gap-3 mt-8">
+          <span class="text-accent-amber font-display text-sm tracking-widest">//</span>
+          Bước 2: Dán mã trả lời từ người nhận
+        </h2>
+
+        <div class="border border-border-default bg-bg-surface p-4">
+          <p class="text-xs text-text-dim mb-2">
+            Sau khi người nhận bấm "Nhận file", họ sẽ nhận được mã trả lời. Dán mã đó vào đây.
+          </p>
+          <textarea
+            v-model="pastedAnswer"
+            placeholder="Dán mã trả lời tại đây..."
+            class="w-full bg-bg-deep border border-border-default p-3 text-xs text-text-primary placeholder:text-text-dim resize-none h-28 focus:border-accent-amber focus:outline-none"
+          />
+          <button
+            :disabled="!pastedAnswer.trim()"
+            class="mt-3 border border-accent-coral bg-accent-coral/10 px-4 py-2 text-sm font-display text-accent-coral transition hover:bg-accent-coral/20 disabled:opacity-30 disabled:cursor-not-allowed"
+            @click="handleAcceptAnswer"
+          >
+            Kết nối & Gửi file
+          </button>
+        </div>
+      </div>
+
+      <!-- STATE: JOINING (Receiver) — Show answer for copy back -->
+      <div v-if="state === 'joining'" class="space-y-6 animate-fade-up">
+        <h2 class="font-display text-2xl font-semibold flex items-center gap-3">
+          <span class="text-accent-sky font-display text-sm tracking-widest">//</span>
+          Gửi mã trả lời cho người gửi
+        </h2>
+
+        <div class="border border-border-default bg-bg-surface p-4">
+          <p v-if="isLoading" class="text-sm text-text-dim py-4 text-center animate-pulse">
+            {{ loadingMessages[loadingMsgIndex] }}
+          </p>
+          <template v-else>
+            <p class="text-xs text-accent-sky mb-2">
+              Mã trả lời đã tự động copy! Gửi lại cho người gửi — họ dán vào ô "Bước 2".
+            </p>
+            <textarea
+              :value="answerSdp"
+              readonly
+              class="w-full bg-bg-deep border border-border-default p-3 text-xs text-text-secondary resize-none h-28 focus:outline-none"
+            />
+            <button
+              :disabled="!answerSdp"
+              class="mt-3 border border-accent-sky bg-accent-sky/10 px-4 py-2 text-sm font-display text-accent-sky transition hover:bg-accent-sky/20 disabled:opacity-30 disabled:cursor-not-allowed"
+              @click="copyToClipboard(answerSdp)"
+            >
+              {{ copied ? 'Đã copy!' : 'Copy mã trả lời' }}
+            </button>
+          </template>
+        </div>
+
+        <p class="text-xs text-text-dim text-center">
+          Đang chờ người gửi kết nối... File sẽ được chuyển tự động khi kết nối thành công.
+        </p>
+      </div>
+
+      <!-- STATE: TRANSFERRING -->
+      <div v-if="state === 'transferring'" class="space-y-6 animate-fade-up">
+        <h2 class="font-display text-2xl font-semibold flex items-center gap-3">
+          <span class="text-accent-amber font-display text-sm tracking-widest">//</span>
+          Đang chuyển file...
+        </h2>
+
+        <!-- Sender progress -->
+        <div v-if="selectedFiles.length > 0" class="border border-border-default bg-bg-surface p-4 space-y-3">
+          <div class="flex items-center justify-between text-sm">
+            <span class="text-text-secondary">Đang gửi...</span>
+            <span class="text-accent-coral font-display">{{ sendProgress }}%</span>
+          </div>
+          <div class="w-full h-2 bg-bg-deep border border-border-default overflow-hidden">
+            <div
+              class="h-full bg-accent-coral transition-all duration-300"
+              :style="{ width: sendProgress + '%' }"
+            />
+          </div>
+          <p class="text-xs text-text-dim">{{ formatBytes(totalBytes) }} tổng cộng</p>
+        </div>
+
+        <!-- Receiver progress -->
+        <div v-if="incomingFiles.length > 0" class="border border-border-default bg-bg-surface p-4 space-y-3">
+          <div class="flex items-center justify-between text-sm">
+            <span class="text-text-secondary">Đang nhận...</span>
+            <span class="text-accent-sky font-display">{{ receiveProgress }}%</span>
+          </div>
+          <div class="w-full h-2 bg-bg-deep border border-border-default overflow-hidden">
+            <div
+              class="h-full bg-accent-sky transition-all duration-300"
+              :style="{ width: receiveProgress + '%' }"
+            />
+          </div>
+          <p class="text-xs text-text-dim">
+            {{ formatBytes(bytesReceived) }} / {{ formatBytes(receiveTotalBytes) }}
+          </p>
+          <div class="space-y-1 mt-2">
+            <div
+              v-for="(file, i) in incomingFiles"
+              :key="i"
+              class="flex items-center justify-between text-xs px-2 py-1"
+            >
+              <span class="text-text-secondary truncate mr-2">{{ file.name }}</span>
+              <span class="text-text-dim">{{ formatBytes(file.size) }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- STATE: COMPLETE -->
+      <div v-if="state === 'complete'" class="space-y-6 animate-fade-up">
+        <h2 class="font-display text-2xl font-semibold flex items-center gap-3">
+          <span class="text-accent-coral font-display text-sm tracking-widest">//</span>
+          Hoàn tất!
+        </h2>
+
+        <!-- Sender complete -->
+        <div v-if="selectedFiles.length > 0 && !downloadReady" class="border border-accent-coral/30 bg-accent-coral/5 p-6 text-center">
+          <p class="text-lg text-accent-coral font-display font-semibold mb-2">Đã gửi thành công!</p>
+          <p class="text-sm text-text-secondary">
+            {{ selectedFiles.length }} file ({{ formatBytes(totalBytes) }}) đã được gửi.
+          </p>
+        </div>
+
+        <!-- Receiver complete -->
+        <div v-if="downloadReady" class="border border-accent-sky/30 bg-accent-sky/5 p-6 text-center space-y-4">
+          <p class="text-lg text-accent-sky font-display font-semibold mb-2">Đã nhận thành công!</p>
+          <p class="text-sm text-text-secondary">
+            {{ incomingFiles.length }} file ({{ formatBytes(receiveTotalBytes) }})
+          </p>
+          <button
+            class="w-full border border-accent-sky bg-accent-sky/10 px-4 py-3 text-sm font-display text-accent-sky transition hover:bg-accent-sky/20"
+            @click="downloadFiles"
+          >
+            Tải file về máy
+          </button>
+        </div>
+
+        <button
+          class="w-full border border-border-default bg-bg-surface px-4 py-2.5 text-sm font-display text-text-secondary transition hover:border-accent-coral hover:text-text-primary"
+          @click="disconnect"
+        >
+          Gửi/nhận file khác
+        </button>
+      </div>
+
+      <!-- Back link -->
+      <RouterLink
+        to="/"
+        class="mt-10 inline-flex items-center gap-2 border border-border-default bg-bg-surface px-5 py-2.5 text-sm text-text-secondary transition hover:border-accent-coral hover:text-text-primary animate-fade-up animate-delay-3"
+      >
+        &larr; Về trang chủ
+      </RouterLink>
+    </div>
+
+    <!-- Guideline modal -->
+    <PeerDropGuidelineModal :open="showGuideline" @close="showGuideline = false" />
+  </div>
+</template>

--- a/src/views/peer-drop/meta.ts
+++ b/src/views/peer-drop/meta.ts
@@ -1,0 +1,10 @@
+import type { PageMeta } from '@/types/page'
+
+const meta: PageMeta = {
+  name: 'Peer Drop',
+  description: 'Gửi file P2P trực tiếp qua trình duyệt — không cần server!',
+  author: 'Nolan',
+  facebook: 'https://github.com/dongnguyenvie',
+}
+
+export default meta

--- a/src/views/peer-drop/peer-drop-guideline-modal.vue
+++ b/src/views/peer-drop/peer-drop-guideline-modal.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+defineProps<{ open: boolean }>()
+const emit = defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+        @click.self="emit('close')"
+      >
+        <div
+          class="relative w-full max-w-2xl max-h-[85vh] overflow-y-auto bg-bg-deep border border-border-default shadow-2xl"
+        >
+          <!-- Header -->
+          <div class="sticky top-0 z-10 bg-bg-deep border-b border-border-default px-6 py-4 flex items-center justify-between">
+            <div>
+              <h2 class="font-display text-xl font-bold text-text-primary">Cách gửi file với Peer Drop</h2>
+              <p class="text-xs text-text-dim mt-1">Chỉ 4 bước đơn giản!</p>
+            </div>
+            <button
+              class="text-text-dim hover:text-text-primary transition p-1"
+              @click="emit('close')"
+            >
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path d="M5 5L15 15M15 5L5 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Steps -->
+          <div class="px-6 py-6 space-y-8">
+
+            <!-- Step 1 -->
+            <section>
+              <h3 class="font-display text-lg font-semibold text-accent-coral mb-1 flex items-center gap-2">
+                <span class="inline-flex items-center justify-center w-7 h-7 border border-accent-coral text-sm">1</span>
+                Chọn file
+              </h3>
+              <p class="text-sm text-text-secondary">
+                Kéo thả hoặc bấm chọn file bạn muốn gửi. Hỗ trợ nhiều file cùng lúc.
+              </p>
+            </section>
+
+            <!-- Step 2 -->
+            <section>
+              <h3 class="font-display text-lg font-semibold text-accent-amber mb-1 flex items-center gap-2">
+                <span class="inline-flex items-center justify-center w-7 h-7 border border-accent-amber text-sm">2</span>
+                Tạo link mời & gửi cho người nhận
+              </h3>
+              <p class="text-sm text-text-secondary">
+                Bấm <strong class="text-text-primary">Tạo link mời</strong>, link sẽ tự động copy.
+                Gửi link qua Messenger, Zalo, Telegram...
+              </p>
+            </section>
+
+            <!-- Step 3 -->
+            <section>
+              <h3 class="font-display text-lg font-semibold text-accent-sky mb-1 flex items-center gap-2">
+                <span class="inline-flex items-center justify-center w-7 h-7 border border-accent-sky text-sm">3</span>
+                Người nhận mở link & gửi mã trả lời
+              </h3>
+              <p class="text-sm text-text-secondary">
+                Người nhận mở link &rarr; bấm <strong class="text-text-primary">Nhận file</strong>
+                &rarr; copy <strong class="text-text-primary">mã trả lời</strong> gửi lại cho bạn.
+              </p>
+            </section>
+
+            <!-- Step 4 -->
+            <section>
+              <h3 class="font-display text-lg font-semibold text-accent-coral mb-1 flex items-center gap-2">
+                <span class="inline-flex items-center justify-center w-7 h-7 border border-accent-coral text-sm">4</span>
+                Dán mã trả lời & chuyển file tự động!
+              </h3>
+              <p class="text-sm text-text-secondary">
+                Bạn dán mã trả lời vào &rarr; kết nối thành công &rarr; file được gửi trực tiếp P2P.
+                Người nhận tải file về máy ngay khi hoàn tất.
+              </p>
+            </section>
+
+            <!-- Note -->
+            <div class="border border-border-default bg-bg-surface p-4">
+              <p class="text-xs text-text-dim">
+                <strong class="text-text-secondary">Lưu ý:</strong>
+                File được gửi trực tiếp giữa 2 trình duyệt qua WebRTC, không qua bất kỳ server nào.
+                Bảo mật tuyệt đối — không ai có thể đọc được file của bạn.
+              </p>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="sticky bottom-0 bg-bg-deep border-t border-border-default px-6 py-4">
+            <button
+              class="w-full border border-accent-coral bg-accent-coral/10 px-4 py-2.5 text-sm font-display text-accent-coral transition hover:bg-accent-coral/20"
+              @click="emit('close')"
+            >
+              Đã hiểu!
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.25s ease;
+}
+.modal-enter-active > div,
+.modal-leave-active > div {
+  transition: transform 0.25s ease;
+}
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+.modal-enter-from > div {
+  transform: scale(0.95) translateY(10px);
+}
+.modal-leave-to > div {
+  transform: scale(0.95) translateY(10px);
+}
+</style>

--- a/src/views/peer-drop/use-webrtc-file-transfer.ts
+++ b/src/views/peer-drop/use-webrtc-file-transfer.ts
@@ -1,0 +1,422 @@
+import { ref, onUnmounted } from 'vue'
+
+/** STUN + TURN servers for NAT traversal */
+const ICE_SERVERS: RTCConfiguration = {
+  iceServers: [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:openrelay.metered.ca:80' },
+    {
+      urls: 'turn:openrelay.metered.ca:80',
+      username: 'openrelayproject',
+      credential: 'openrelayproject',
+    },
+    {
+      urls: 'turn:openrelay.metered.ca:443',
+      username: 'openrelayproject',
+      credential: 'openrelayproject',
+    },
+    {
+      urls: 'turn:openrelay.metered.ca:443?transport=tcp',
+      username: 'openrelayproject',
+      credential: 'openrelayproject',
+    },
+  ],
+}
+
+const CHUNK_SIZE = 16384 // 16KB per chunk
+
+export type TransferState =
+  | 'idle'
+  | 'files-ready'
+  | 'creating-offer'
+  | 'waiting-answer'
+  | 'joining'
+  | 'transferring'
+  | 'complete'
+  | 'error'
+
+export interface FileInfo {
+  name: string
+  size: number
+  type: string
+}
+
+/** Encode SDP JSON to base64 for safe copy/paste */
+function sdpToBase64(sdpJson: string): string {
+  return btoa(sdpJson)
+}
+
+/** Decode base64 SDP back to JSON string */
+function base64ToSdp(input: string): string {
+  const trimmed = input.trim()
+  if (trimmed.startsWith('{')) return trimmed
+  try {
+    return atob(trimmed)
+  } catch {
+    return trimmed
+  }
+}
+
+/** Format bytes to human readable string */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  return `${(bytes / Math.pow(1024, i)).toFixed(i > 0 ? 1 : 0)} ${units[i]}`
+}
+
+export function useWebrtcFileTransfer() {
+  const state = ref<TransferState>('idle')
+  const errorMessage = ref('')
+  const isLoading = ref(false)
+  const offerSdp = ref('')
+  const answerSdp = ref('')
+
+  // Sender state
+  const selectedFiles = ref<File[]>([])
+  const sendProgress = ref(0) // 0-100
+  const bytesSent = ref(0)
+  const totalBytes = ref(0)
+
+  // Receiver state
+  const incomingFiles = ref<FileInfo[]>([])
+  const receiveProgress = ref(0) // 0-100
+  const bytesReceived = ref(0)
+  const receiveTotalBytes = ref(0)
+  const downloadReady = ref(false)
+
+  let pc: RTCPeerConnection | null = null
+  let dataChannel: RTCDataChannel | null = null
+  let receivedChunks: ArrayBuffer[] = []
+  let receivedFilesMeta: FileInfo[] = []
+  let currentFileIndex = 0
+  let currentFileReceived = 0
+  let completedFiles: { blob: Blob; name: string }[] = []
+
+  /** Select files to send */
+  function selectFiles(files: File[]) {
+    selectedFiles.value = files
+    totalBytes.value = files.reduce((sum, f) => sum + f.size, 0)
+    state.value = 'files-ready'
+  }
+
+  /** Remove a file from selection */
+  function removeFile(index: number) {
+    selectedFiles.value.splice(index, 1)
+    totalBytes.value = selectedFiles.value.reduce((sum, f) => sum + f.size, 0)
+    if (selectedFiles.value.length === 0) {
+      state.value = 'idle'
+    }
+  }
+
+  /** Create peer connection (no media, data channel only) */
+  function createPeerConnection() {
+    pc = new RTCPeerConnection(ICE_SERVERS)
+
+    pc.oniceconnectionstatechange = () => {
+      const iceState = pc?.iceConnectionState
+      if (iceState === 'failed' || iceState === 'disconnected') {
+        if (state.value === 'transferring') {
+          errorMessage.value = 'Kết nối bị gián đoạn. Vui lòng thử lại.'
+          state.value = 'error'
+        }
+      }
+    }
+
+    return pc
+  }
+
+  /** Wait until ICE gathering completes */
+  function waitForIceGathering(conn: RTCPeerConnection): Promise<string> {
+    return new Promise((resolve) => {
+      const resolveSdp = () => resolve(JSON.stringify(conn.localDescription))
+
+      if (conn.iceGatheringState === 'complete') {
+        resolveSdp()
+        return
+      }
+
+      const timeout = setTimeout(() => {
+        conn.onicegatheringstatechange = null
+        resolveSdp()
+      }, 10_000)
+
+      conn.onicegatheringstatechange = () => {
+        if (conn.iceGatheringState === 'complete') {
+          clearTimeout(timeout)
+          resolveSdp()
+        }
+      }
+    })
+  }
+
+  /** Sender: create offer with data channel */
+  async function createOffer(): Promise<string> {
+    isLoading.value = true
+    state.value = 'creating-offer'
+    errorMessage.value = ''
+
+    const conn = createPeerConnection()
+
+    // Create data channel for file transfer
+    dataChannel = conn.createDataChannel('file-transfer', { ordered: true })
+    dataChannel.binaryType = 'arraybuffer'
+
+    dataChannel.onopen = () => {
+      sendAllFiles()
+    }
+
+    const offer = await conn.createOffer()
+    await conn.setLocalDescription(offer)
+
+    const fullSdp = await waitForIceGathering(conn)
+    const encoded = sdpToBase64(fullSdp)
+    offerSdp.value = encoded
+    isLoading.value = false
+    state.value = 'waiting-answer'
+    return encoded
+  }
+
+  /** Receiver: join with offer, setup data channel listener */
+  async function joinWithOffer(offerText: string): Promise<string> {
+    isLoading.value = true
+    state.value = 'joining'
+    errorMessage.value = ''
+
+    const conn = createPeerConnection()
+
+    // Listen for incoming data channel
+    conn.ondatachannel = (event) => {
+      dataChannel = event.channel
+      dataChannel.binaryType = 'arraybuffer'
+      setupReceiverHandlers()
+    }
+
+    try {
+      const decoded = base64ToSdp(offerText)
+      const parsed = JSON.parse(decoded)
+      await conn.setRemoteDescription(parsed)
+    } catch (err) {
+      const msg =
+        err instanceof SyntaxError
+          ? 'Mã mời không đúng định dạng. Vui lòng kiểm tra đã copy đủ chưa.'
+          : 'Mã mời không hợp lệ. Vui lòng thử lại.'
+      errorMessage.value = msg
+      state.value = 'error'
+      isLoading.value = false
+      throw err
+    }
+
+    const answer = await conn.createAnswer()
+    await conn.setLocalDescription(answer)
+
+    const fullSdp = await waitForIceGathering(conn)
+    const encoded = sdpToBase64(fullSdp)
+    answerSdp.value = encoded
+    isLoading.value = false
+    return encoded
+  }
+
+  /** Sender: accept answer to complete connection */
+  async function acceptAnswer(answerText: string) {
+    if (!pc) {
+      errorMessage.value = 'Kết nối đã hết hạn. Vui lòng tạo lại.'
+      state.value = 'error'
+      return
+    }
+    try {
+      const decoded = base64ToSdp(answerText)
+      const parsed = JSON.parse(decoded)
+      await pc.setRemoteDescription(parsed)
+    } catch (err) {
+      const msg =
+        err instanceof SyntaxError
+          ? 'Mã trả lời không đúng định dạng.'
+          : 'Mã trả lời không hợp lệ.'
+      errorMessage.value = msg
+      state.value = 'error'
+    }
+  }
+
+  /** Sender: stream all files over data channel */
+  async function sendAllFiles() {
+    if (!dataChannel || dataChannel.readyState !== 'open') return
+    state.value = 'transferring'
+    bytesSent.value = 0
+
+    const dc = dataChannel
+
+    // Send file metadata first
+    const meta: FileInfo[] = selectedFiles.value.map((f) => ({
+      name: f.name,
+      size: f.size,
+      type: f.type,
+    }))
+    dc.send(JSON.stringify({ type: 'meta', files: meta }))
+
+    // Send each file in chunks
+    for (const file of selectedFiles.value) {
+      const buffer = await file.arrayBuffer()
+      let offset = 0
+
+      while (offset < buffer.byteLength) {
+        // Backpressure: wait if buffer is too full
+        if (dc.bufferedAmount > 65536) {
+          await new Promise<void>((resolve) => {
+            dc.bufferedAmountLowThreshold = 16384
+            dc.onbufferedamountlow = () => {
+              dc.onbufferedamountlow = null
+              resolve()
+            }
+          })
+        }
+
+        const end = Math.min(offset + CHUNK_SIZE, buffer.byteLength)
+        dc.send(buffer.slice(offset, end))
+        offset = end
+        bytesSent.value += end - (offset - (end - offset))
+        // Recalculate properly
+        bytesSent.value = Math.min(
+          selectedFiles.value
+            .slice(0, selectedFiles.value.indexOf(file))
+            .reduce((s, f) => s + f.size, 0) + offset,
+          totalBytes.value,
+        )
+        sendProgress.value = Math.round((bytesSent.value / totalBytes.value) * 100)
+      }
+
+      // Signal end of this file
+      dc.send(JSON.stringify({ type: 'file-end', name: file.name }))
+    }
+
+    // Signal all files done
+    dc.send(JSON.stringify({ type: 'all-done' }))
+    sendProgress.value = 100
+    state.value = 'complete'
+  }
+
+  /** Receiver: handle incoming data channel messages */
+  function setupReceiverHandlers() {
+    if (!dataChannel) return
+    const dc = dataChannel
+
+    dc.onmessage = (event) => {
+      // Text message (JSON control)
+      if (typeof event.data === 'string') {
+        try {
+          const msg = JSON.parse(event.data)
+
+          if (msg.type === 'meta') {
+            receivedFilesMeta = msg.files as FileInfo[]
+            incomingFiles.value = receivedFilesMeta
+            receiveTotalBytes.value = receivedFilesMeta.reduce((s: number, f: FileInfo) => s + f.size, 0)
+            currentFileIndex = 0
+            currentFileReceived = 0
+            receivedChunks = []
+            completedFiles = []
+            bytesReceived.value = 0
+            state.value = 'transferring'
+          }
+
+          if (msg.type === 'file-end') {
+            // Assemble current file
+            const blob = new Blob(receivedChunks, {
+              type: receivedFilesMeta[currentFileIndex]?.type || 'application/octet-stream',
+            })
+            completedFiles.push({
+              blob,
+              name: msg.name,
+            })
+            currentFileIndex++
+            currentFileReceived = 0
+            receivedChunks = []
+          }
+
+          if (msg.type === 'all-done') {
+            receiveProgress.value = 100
+            downloadReady.value = true
+            state.value = 'complete'
+          }
+        } catch {
+          // Not JSON, ignore
+        }
+        return
+      }
+
+      // Binary data (file chunk)
+      const chunk = event.data as ArrayBuffer
+      receivedChunks.push(chunk)
+      currentFileReceived += chunk.byteLength
+      bytesReceived.value += chunk.byteLength
+      receiveProgress.value = Math.round(
+        (bytesReceived.value / receiveTotalBytes.value) * 100,
+      )
+    }
+  }
+
+  /** Receiver: trigger download for all received files */
+  function downloadFiles() {
+    for (const file of completedFiles) {
+      const url = URL.createObjectURL(file.blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = file.name
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+  }
+
+  /** Reset everything */
+  function disconnect() {
+    dataChannel?.close()
+    dataChannel = null
+    pc?.close()
+    pc = null
+    state.value = 'idle'
+    errorMessage.value = ''
+    isLoading.value = false
+    offerSdp.value = ''
+    answerSdp.value = ''
+    selectedFiles.value = []
+    sendProgress.value = 0
+    bytesSent.value = 0
+    totalBytes.value = 0
+    incomingFiles.value = []
+    receiveProgress.value = 0
+    bytesReceived.value = 0
+    receiveTotalBytes.value = 0
+    downloadReady.value = false
+    receivedChunks = []
+    receivedFilesMeta = []
+    currentFileIndex = 0
+    currentFileReceived = 0
+    completedFiles = []
+  }
+
+  onUnmounted(disconnect)
+
+  return {
+    state,
+    errorMessage,
+    isLoading,
+    offerSdp,
+    answerSdp,
+    selectedFiles,
+    sendProgress,
+    bytesSent,
+    totalBytes,
+    incomingFiles,
+    receiveProgress,
+    bytesReceived,
+    receiveTotalBytes,
+    downloadReady,
+    selectFiles,
+    removeFile,
+    createOffer,
+    joinWithOffer,
+    acceptAnswer,
+    downloadFiles,
+    disconnect,
+    formatBytes,
+  }
+}


### PR DESCRIPTION

## Mô tả thay đổi

Thêm trang **Peer Drop** — gửi file P2P trực tiếp qua trình duyệt bằng WebRTC DataChannel, không cần server.

### Tính năng
- Kéo thả / chọn file, hỗ trợ nhiều file cùng lúc
- Tạo link mời có chứa metadata file (người nhận thấy tên + dung lượng trước khi nhận)
- Gửi file chunked (16KB) với backpressure để tránh tràn bộ nhớ
- Thanh tiến trình cho cả người gửi và người nhận
- Tự động trigger download khi hoàn tất
- Signaling qua copy/paste SDP (giống Peer Call)
- STUN/TURN servers cho NAT traversal
- Modal hướng dẫn 4 bước

#### Người gửi

https://github.com/user-attachments/assets/3d4691b0-7738-4c43-b7f5-e419d5dc5a06

#### Người nhận


https://github.com/user-attachments/assets/a9a092bc-c05a-48ba-9e2d-257f6f741c7d





### Files
- `src/views/peer-drop/index.vue` — Giao diện chính
- `src/views/peer-drop/meta.ts` — Metadata trang
- `src/views/peer-drop/use-webrtc-file-transfer.ts` — Composable WebRTC DataChannel
- `src/views/peer-drop/peer-drop-guideline-modal.vue` — Modal hướng dẫn

## Loại thay đổi

- [x] Thêm trang mới (`src/views/peer-drop/`)
- [ ] Sửa lỗi (bug fix)
- [ ] Cải tiến (enhancement)
- [ ] Khác

## Checklist

- [x] Đã chạy `pnpm lint` và không có lỗi
- [x] Đã chạy `pnpm build` thành công
- [x] Đã tạo file `meta.ts` trong thư mục trang (nếu tạo trang mới)
- [x] Tuân thủ [Design System](docs/DESIGN_SYSTEM.md)
